### PR TITLE
ci: Add artifact uploads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,21 @@ git:
 
 script:
   - make
+
+before_deploy:
+  # Set up git user name and tag this commit
+  - git config --local user.name "TravisCI"
+  - git config --local user.email "no-reply@xboxdev.org"
+  # If this is a tagged build use the tag name, otherwise use build-YYYYMMDD-<commit>
+  - export TRAVIS_TAG=${TRAVIS_TAG:-build-$(date +'%Y%m%d')-$(git log --format=%h -1)}
+  - git tag $TRAVIS_TAG
+deploy:
+  provider: releases
+  api_key:
+    # Encrypted via `travis encrypt -r "xboxdev/cromwell" <token>`
+    secure: "BTQLHURpDrg1mbcjKEkOZG8GfHAb/ixrCmJewYdEWuagGMyxzq28fvR1B15ROYG+K9E3Ac76ofySO0TUt/Cc5USqBF3SMBJUb5RnoWGfHX6X1JTN7ThUPnWQS5RVRJfd3MNvycsuE3sJh8vB0S7YyD2WLqDq2LhBqyFv3+4BYS7mAWKX+pT1oGGQuzhcwI6U/dgjM26nkqyACIqRB+piMdo4JOu9q1nuJLIqy2c7Cgu7YUJG5kBWH0A1imiPmqJ4ImdhdlUpjO/eCPFP66ixqTGkn0bPjiPPnvAJlVAwR35CSO+X3lvKmrvQNU7rP+IbBuhxdBSfiePg8np8+M3rs6KKGvGujeyiV7JOsGksCWWaH/vVSs/OtxG9r0v8tKKjX+aLHBKsKo24qQEzFn1wa4+0iB1raVx4cvbOxtpdB5xHI6biqKmzHKosxx6qKvE7MGlwXo58su/mqrKY/VUJmnoHi+5D3qQlUnI0NdnXcIjmeJ0zzQw2KTs02Ps8gaeHIls638DFLE+kFk0raR+QJ0Sdz0HVGh5eZftqSqpCfXstPt3/rdCUgkSkbir8U5MwVYbOBk5Upo77JFTX0sCBLeKnXw16xtaVTwjOP3wcStQgGKhm/k0bpu4qXtEKZHe4TcOv1IAE2MVKoT508vnKTj+5Fg+czNEoPVzjedWITuQ="
+  file:
+    - "image/cromwell.bin"
+    - "image/cromwell_1024.bin"
+    - "xbe/xromwell.xbe"
+  skip_cleanup: true


### PR DESCRIPTION
This PR adds a deployment step to Travis that will upload [cx]romwell binaries to GitHub. If a tag is pushed, the tag name will be used as the release label, otherwise a release label will be generated in the form of `build-YYYYMMDD-<7 char commit hash>`

Closes #10 