### PR TITLE
ui: Add Git revision and XboxDev repository link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,19 @@ CC	= gcc
 # prepare check for gcc 3.3, $(GCC_3.3) will either be 0 or 1
 GCC_3.3 := $(shell expr `$(CC) -dumpversion` \>= 3.3)
 
+SRC_PATH=.
+
+GITREV = $(shell \
+  cd $(SRC_PATH); \
+  if test -e .git; then \
+    git rev-parse --short HEAD 2>/dev/null | tr -d '\n'; \
+    if ! git diff --quiet HEAD &>/dev/null; then \
+      echo "-dirty"; \
+    fi; \
+  else \
+    echo "unknown"; \
+  fi)
+
 ETHERBOOT := yes
 INCLUDE = -I$(TOPDIR)/grub -I$(TOPDIR)/include -I$(TOPDIR)/ -I./ -I$(TOPDIR)/fs/cdrom \
 	-I$(TOPDIR)/fs/fatx -I$(TOPDIR)/fs/grub -I$(TOPDIR)/lib/eeprom -I$(TOPDIR)/lib/crypt \
@@ -11,7 +24,7 @@ INCLUDE = -I$(TOPDIR)/grub -I$(TOPDIR)/include -I$(TOPDIR)/ -I./ -I$(TOPDIR)/fs/
 	-I$(TOPDIR)/lib/jpeg/ -I$(TOPDIR)/menu/actions -I$(TOPDIR)/menu/textmenu -I$(TOPDIR)/menu/iconmenu
 
 #These are intended to be non-overridable.
-CROM_CFLAGS=$(INCLUDE) -m32 -fno-builtin -fno-stack-protector -no-pie
+CROM_CFLAGS=$(INCLUDE) -m32 -fno-builtin -fno-stack-protector -no-pie -DGITREV=\\\"$(GITREV)\\\"
 
 #You can override these if you wish.
 CFLAGS= -m32 -O2 -g -march=pentium -pipe -fomit-frame-pointer -Wstrict-prototypes -fno-builtin -fno-stack-protector -no-pie

--- a/boot/BootResetAction.c
+++ b/boot/BootResetAction.c
@@ -112,15 +112,14 @@ extern void BootResetAction ( void ) {
 	VIDEO_CURSOR_POSY=vmode.ymargin;
 	VIDEO_CURSOR_POSX=(vmode.xmargin/*+64*/)*4;
 #ifndef SILENT_MODE	
-	if (cromwell_config==XROMWELL) 	printk("\2Xbox Linux Xromwell  " VERSION "\2\n" );
-	if (cromwell_config==CROMWELL)	printk("\2Xbox Linux Cromwell BIOS  " VERSION "\2\n" );
+	if (cromwell_config==XROMWELL) 	printk("\2Xromwell " VERSION "\2\n" );
+	if (cromwell_config==CROMWELL)	printk("\2Cromwell BIOS " VERSION "\2\n" );
 	VIDEO_CURSOR_POSY=vmode.ymargin+32;
 	VIDEO_CURSOR_POSX=(vmode.xmargin/*+64*/)*4;
-	printk( __DATE__ " -  http://xbox-linux.org\n");
+	printk( __DATE__ " (rev. %s) -  https://github.com/XboxDev/cromwell\n", GITREV);
 	VIDEO_CURSOR_POSX=(vmode.xmargin/*+64*/)*4;
-	printk("(C)2002-2004 Xbox Linux Team   RAM : %d MB  ",xbox_ram);
-        printk("\n");
-    
+	printk("Available RAM: %d MB\n",xbox_ram);
+
 	// capture title area
 	VIDEO_ATTR=0xffc8c8c8;
 	printk("Encoder: ");


### PR DESCRIPTION
Fixes #11.

Some observations and notes:
- Cromwell uses `XBOXLINUX` password for IDE locking, I think we can leave it as is
- There is Linux logo in `/boot_xbe/xbe.S`, but I don't know in which format the bitmap is encoded