### PR TITLE
ReactOS boot support bringup PR (3 of 3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ OBJECTS-CROM += $(TOPDIR)/obj/cputools.o
 OBJECTS-CROM += $(TOPDIR)/obj/microcode.o
 OBJECTS-CROM += $(TOPDIR)/obj/ioapic.o
 OBJECTS-CROM += $(TOPDIR)/obj/BootInterrupts.o
+OBJECTS-CROM += $(TOPDIR)/obj/fsys_fat.o
 OBJECTS-CROM += $(TOPDIR)/obj/fsys_reiserfs.o
 OBJECTS-CROM += $(TOPDIR)/obj/fsys_ext2fs.o
 OBJECTS-CROM += $(TOPDIR)/obj/fsys_ufs2.o

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ OBJECTS-CROM += $(TOPDIR)/obj/HddMenuActions.o
 OBJECTS-CROM += $(TOPDIR)/obj/PhyMenuActions.o
 OBJECTS-CROM += $(TOPDIR)/obj/Confirm.o
 OBJECTS-CROM += $(TOPDIR)/obj/LoadLinux.o
+OBJECTS-CROM += $(TOPDIR)/obj/LoadReactOS.o
 OBJECTS-CROM += $(TOPDIR)/obj/BootFromDevice.o
 OBJECTS-CROM += $(TOPDIR)/obj/setup.o
 OBJECTS-CROM += $(TOPDIR)/obj/iso9660.o

--- a/boot/BootFromDevice.c
+++ b/boot/BootFromDevice.c
@@ -100,6 +100,7 @@ CONFIGENTRY *AddNestedConfigEntry(CONFIGENTRY *config, CONFIGENTRY *nested, char
 CONFIGENTRY *DetectSystemNative(int drive, int partition) {
 	CONFIGENTRY *config = NULL;
 	CONFIGENTRY *cfgLinux;
+	CONFIGENTRY *cfgReactOS;
 	char *szGrub;
 
 	szGrub = InitGrubRequest(GRUB_REQUEST_SIZE, drive, partition);
@@ -107,6 +108,11 @@ CONFIGENTRY *DetectSystemNative(int drive, int partition) {
 	if (cfgLinux != NULL) {
 		FillConfigEntries(cfgLinux, BOOT_NATIVE, drive, partition);
 		config = AddNestedConfigEntry(config, cfgLinux, "Linux");
+	}
+	cfgReactOS = DetectReactOSNative(szGrub);
+	if (cfgReactOS != NULL) {
+		FillConfigEntries(cfgReactOS, BOOT_NATIVE, drive, partition);
+		config = AddNestedConfigEntry(config, cfgReactOS, "ReactOS");
 	}
 	free(szGrub);
 
@@ -122,6 +128,8 @@ int BootFromNative(CONFIGENTRY *config) {
 	szGrub = InitGrubRequest(GRUB_REQUEST_SIZE, config->drive, config->partition);
 	if (config->bootSystem == SYS_LINUX)
 		result = LoadLinuxNative(szGrub, &config->opt.Linux);
+	if (config->bootSystem == SYS_REACTOS)
+		result = LoadReactOSNative(szGrub, config);
 	free(szGrub);
 
 	return result;

--- a/boot/LoadReactOS.c
+++ b/boot/LoadReactOS.c
@@ -1,0 +1,415 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   Copyright (C) 2007 Ge van Geldorp                                     *
+ *   Copyright (C) 2019 Stanislav Motylkov                                 *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "boot.h"
+#include "BootFATX.h"
+#include "memory_layout.h"
+
+/* Length of area to be searched for multiboot header. */
+#define MULTIBOOT_SEARCHAREA_LEN        8192
+
+/* Magic numbers for the Multiboot 1 specification. */
+#define MULTIBOOT_HEADER_MAGIC          0x1BADB002
+#define MULTIBOOT_BOOTLOADER_MAGIC      0x2BADB002
+
+#define MB_INFO_FLAG_MEM_SIZE           0x00000001
+#define MB_INFO_FLAG_BOOT_DEVICE        0x00000002
+#define MB_INFO_FLAG_COMMAND_LINE       0x00000004
+#define MB_INFO_FLAG_MODULES            0x00000008
+#define MB_INFO_FLAG_AOUT_SYMS          0x00000010
+#define MB_INFO_FLAG_ELF_SYMS           0x00000020
+#define MB_INFO_FLAG_MEMORY_MAP         0x00000040
+#define MB_INFO_FLAG_DRIVES             0x00000080
+#define MB_INFO_FLAG_CONFIG_TABLE       0x00000100
+#define MB_INFO_FLAG_BOOT_LOADER_NAME   0x00000200
+#define MB_INFO_FLAG_APM_TABLE          0x00000400
+#define MB_INFO_FLAG_GRAPHICS_TABLE     0x00000800
+
+/* The Multiboot header. */
+typedef struct tagMULTIBOOTHEADER {
+	u32 magic;
+	u32 flags;
+	u32 checksum;
+	u32 header_addr;
+	u32 load_addr;
+	u32 load_end_addr;
+	u32 bss_end_addr;
+	u32 entry_addr;
+} MULTIBOOTHEADER, *PMULTIBOOTHEADER;
+
+/* The symbol table for a.out. */
+typedef struct tagAOUTSYMBOLTABLE {
+	u32 tabsize;
+	u32 strsize;
+	u32 addr;
+	u32 reserved;
+} AOUTSYMBOLTABLE, *PAOUTSYMBOLTABLE;
+
+/* The section header table for ELF. */
+typedef struct tagELFSECTIONHEADERTABLE {
+	u32 num;
+	u32 size;
+	u32 addr;
+	u32 shndx;
+} ELFSECTIONHEADERTABLE, *PELFSECTIONHEADERTABLE;
+
+/* The Multiboot information. */
+typedef struct tagMULTIBOOTINFO {
+	u32 flags;
+	u32 mem_lower;
+	u32 mem_upper;
+	u32 boot_device;
+	u32 cmdline;
+	u32 mods_count;
+	u32 mods_addr;
+	union {
+		AOUTSYMBOLTABLE aout_sym;
+		ELFSECTIONHEADERTABLE elf_sec;
+	} u;
+	u32 mmap_length;
+	u32 mmap_addr;
+	u32 drives_length;
+	u32 drives_addr;
+	u32 config_table;
+	u32 boot_loader_name;
+	u32 apm_table;
+	u32 vbe_control_info;
+	u32 vbe_mode_info;
+	u32 vbe_mode;
+	u32 vbe_interface_seg;
+	u32 vbe_interface_off;
+	u32 vbe_interface_len;
+} MULTIBOOTINFO, *PMULTIBOOTINFO;
+
+/* The memory map. Be careful that the offset 0 is base_addr_low
+   but no size. */
+typedef struct tagMEMORYMAP {
+	u32 size;
+	u32 base_addr_low;
+	u32 base_addr_high;
+	u32 length_low;
+	u32 length_high;
+	u32 type;
+} MEMORYMAP, *PMEMORYMAP;
+
+void startReactOS(PMULTIBOOTHEADER mbHeader, u32 loaderSize, u32 bootDevice);
+
+u32 GetMultibootBootDevice(u8 drive, u8 partition, u8 subpartition1, u8 subpartition2) {
+	return (subpartition2 | (subpartition1 << 8) | (partition << 16) | (drive << 24));
+}
+
+PMULTIBOOTHEADER CheckMultibootHeader(u8 *buffer) {
+	PMULTIBOOTHEADER mbHeader;
+
+	for (mbHeader = (PMULTIBOOTHEADER)buffer;
+		(u8 *)mbHeader - buffer < MULTIBOOT_SEARCHAREA_LEN;
+		mbHeader = (PMULTIBOOTHEADER)((u8 *)mbHeader + 4))
+	{
+		if (mbHeader->magic == MULTIBOOT_HEADER_MAGIC &&
+			mbHeader->magic + mbHeader->flags + mbHeader->checksum == 0) {
+			break;
+		}
+	}
+
+	if ((u8 *)mbHeader - buffer >= MULTIBOOT_SEARCHAREA_LEN) {
+		printk("No multiboot header found\n");
+		return NULL;
+	}
+
+	return mbHeader;
+}
+
+CONFIGENTRY *DetectReactOSFATX(FATXPartition *partition) {
+	FATXFILEINFO fileinfo;
+	CONFIGENTRY *config = NULL;
+
+	if (LoadFATXFile(partition, "/freeldr.sys", &fileinfo)) {
+		// Root of E has a freeldr.sys in
+		config = (CONFIGENTRY *)malloc(sizeof(CONFIGENTRY));
+		memset(config, 0x00, sizeof(CONFIGENTRY));
+		config->bootSystem = SYS_REACTOS;
+		strcpy(config->title, "ReactOS");
+		strcpy(config->szPath, "/freeldr.sys");
+
+		free(fileinfo.buffer);
+	}
+
+	return config;
+}
+
+int LoadReactOSFATX(FATXPartition *partition, CONFIGENTRY *config) {
+	static FATXFILEINFO fileinfo;
+	OPTMULTIBOOT *multiboot = &config->opt.Multiboot;
+
+	memset(&fileinfo, 0x00, sizeof(fileinfo));
+
+	VIDEO_ATTR = 0xffd8d8d8;
+	printk("  Loading %s from FATX", config->szPath);
+	if (!LoadFATXFilefixed(partition, config->szPath, &fileinfo, FREELDR_LOAD_AREA)) {
+		printk("Error loading %s\n", config->szPath);
+		wait_ms(2000);
+		return false;
+	} else {
+		printk(" - %d bytes\n", fileinfo.fileRead);
+
+		if (CheckMultibootHeader(fileinfo.buffer) == NULL) {
+			wait_ms(2000);
+			return false;
+		}
+		multiboot->pBuffer = fileinfo.buffer;
+		multiboot->uBufferSize = fileinfo.fileRead;
+		/* ReactOS FreeLoader and drivers treat FATX (E:) partition as the first one,
+		 * so we specify 0 here as the second argument. */
+		multiboot->uBootDevice = GetMultibootBootDevice(0x80 + partition->nDriveIndex, 0, 0xFF, 0xFF);
+	}
+
+	return true;
+}
+
+CONFIGENTRY *DetectReactOSCD(int cdromId) {
+	long dwSize;
+	CONFIGENTRY *config;
+
+	dwSize = BootIso9660GetFile(cdromId, "/loader/setupldr.sys", FREELDR_LOAD_AREA, FREELDR_MAX_SIZE);
+
+	// Failed to load freeloader
+	if (dwSize <= 0)
+		return NULL;
+
+	// Freeloader found
+	config = (CONFIGENTRY *)malloc(sizeof(CONFIGENTRY));
+	memset(config, 0x00, sizeof(CONFIGENTRY));
+	config->bootSystem = SYS_REACTOS;
+	strcpy(config->title, "ReactOS");
+	strcpy(config->szPath, "/loader/setupldr.sys");
+
+	return config;
+}
+
+int LoadReactOSCD(CONFIGENTRY *config) {
+	long dwSize;
+	OPTMULTIBOOT *multiboot = &config->opt.Multiboot;
+
+	memset(FREELDR_LOAD_AREA, 0, FREELDR_MAX_SIZE);
+
+	VIDEO_ATTR = 0xffd8d8d8;
+	printk("  Loading %s from CD", config->szPath);
+	VIDEO_ATTR = 0xffa8a8a8;
+	dwSize = BootIso9660GetFile(config->drive, config->szPath, FREELDR_LOAD_AREA, FREELDR_MAX_SIZE);
+
+	if (dwSize < 0) {
+		printk("Not Found, error %d\nHalting\n", dwSize); 
+		wait_ms(2000);
+		return false;
+	} else {
+		printk(" - %d bytes\n", dwSize);
+
+		if (CheckMultibootHeader(FREELDR_LOAD_AREA) == NULL) {
+			wait_ms(2000);
+			return false;
+		}
+		multiboot->pBuffer = FREELDR_LOAD_AREA;
+		multiboot->uBufferSize = dwSize;
+		/* Multiboot partition indices starting at 0, FreeLoader will increment 0xFE to 0xFF
+		 * and later it will interpret drive 0xE0 and partition 0xFF as CD drive. */
+		multiboot->uBootDevice = GetMultibootBootDevice(0xE0, 0xFE, 0xFF, 0xFF);
+	}
+
+	return true;
+}
+
+int ExittoReactOS(const OPTMULTIBOOT *multiboot) {
+	PMULTIBOOTHEADER mbHeader;
+
+	mbHeader = CheckMultibootHeader(multiboot->pBuffer);
+	if (mbHeader == NULL)
+		return;
+
+	VIDEO_ATTR = 0xff8888a8;
+	printk("     Multiboot header found at 0x%X\n", mbHeader);
+	printk("     Boot device is 0x%X\n", multiboot->uBootDevice);
+	VIDEO_ATTR = 0xffa8a8a8;
+
+	char *sz = "\2Starting ReactOS\2";
+	VIDEO_CURSOR_POSX = ((vmode.width - BootVideoGetStringTotalWidth(sz)) / 2) * 4;
+	VIDEO_CURSOR_POSY = vmode.height - 64;
+
+	VIDEO_ATTR = 0xff9f9fbf;
+	printk(sz);
+	setLED("rrrr");
+	startReactOS(mbHeader, multiboot->uBufferSize, multiboot->uBootDevice);
+}
+
+void startReactOS(PMULTIBOOTHEADER mbHeader, u32 loaderSize, u32 bootDevice) {
+	PMULTIBOOTINFO mbInfo;
+	PMEMORYMAP mmap;
+	static u32 ldrSize;
+	static u32 bootDev;
+	u32 infoPtr;
+	int nAta = 0;
+
+	if (mbHeader == NULL)
+		return;
+
+	/* Save needed values into static variables, as the stack pointer
+	 * will be modified by inline assembly below */
+	ldrSize = loaderSize;
+	bootDev = bootDevice;
+
+	/* Prepare to move freeldr to its final destination. Since that might
+	 * involve overwriting cromwell structures we shutdown as much as
+	 * possible. After this point, we can't return anymore */
+	BootStopUSB();
+	if (tsaHarddiskInfo[0].m_bCableConductors == 80) {
+		if (tsaHarddiskInfo[0].m_wAtaRevisionSupported & 2) nAta = 1;
+		if (tsaHarddiskInfo[0].m_wAtaRevisionSupported & 4) nAta = 2;
+		if (tsaHarddiskInfo[0].m_wAtaRevisionSupported & 8) nAta = 3;
+		if (tsaHarddiskInfo[0].m_wAtaRevisionSupported & 16) nAta = 4;
+		if (tsaHarddiskInfo[0].m_wAtaRevisionSupported & 32) nAta = 5;
+	} else {
+		// force the HDD into a good mode 0x40 ==UDMA | 2 == UDMA2
+		nAta = 2; // best transfer mode without 80-pin cable
+	}
+	// nAta=1;
+	BootIdeSetTransferMode(0, 0x40 | nAta);
+	BootIdeSetTransferMode(1, 0x40 | nAta);
+
+	/* orange, people seem to like that colour */
+	setLED("oooo");
+
+	/* Do not update framebuffer address, as ReactOS video drivers reuse it as is,
+	 * and do not perform video hardware initialization. See also FIXME below. */
+	//(*(unsigned int *)0xFD600800) = (0xf0000000 | ((xbox_ram * 0x100000) - FB_SIZE));
+
+	/* disable interrupts */
+	asm volatile ("cli\n");
+
+	/* clear IDT area */
+	memset((void *)IDT_LOC, 0x0, 8 * 1024);
+
+	asm volatile (
+	"wbinvd\n"
+
+	/* Flush the TLB */
+	"xor %eax, %eax \n"
+	"mov %eax, %cr3 \n"
+
+	/* Load IDT table (0xB0000 = IDT_LOC) */
+	"lidt 0xB0000\n"
+
+	/* DR6/DR7: Clear the debug registers */
+	"xor %eax, %eax \n"
+	"mov %eax, %dr6 \n"
+	"mov %eax, %dr7 \n"
+	"mov %eax, %dr0 \n"
+	"mov %eax, %dr1 \n"
+	"mov %eax, %dr2 \n"
+	"mov %eax, %dr3 \n"
+
+	/* Kill the LDT, if any */
+	"xor  %eax, %eax \n"
+	"lldt %ax \n"
+
+	/* Reload CS as 0010 from the new GDT using a far jump */
+	"ljmp	$0x0010, $reload_cs_exit \n"
+
+	".align 16  \n"
+	"reload_cs_exit: \n"
+
+	/* CS is now a valid entry in the GDT.  Set the other segment registers
+	 * to valid descriptors (4Gb flat mode) as required by the multiboot
+	 * spec */
+
+	"movw $0x0018, %ax \n"
+	"mov %eax, %ss \n"
+	"mov %eax, %ds \n"
+	"mov %eax, %es \n"
+	"mov %eax, %fs \n"
+	"mov %eax, %gs \n"
+
+	/* Set the stack pointer to give us a valid stack */
+	"movl $0x03BFFFFC, %esp \n"
+	);
+
+	/* Ok, preparations are complete. Now move the image.
+	 * Values of load_end_addr and bss_end_addr can be equal to zero, see:
+	 * https://www.gnu.org/software/grub/manual/multiboot/multiboot.html#Header-address-fields */
+	memcpy((u8 *)mbHeader->load_addr,
+		(u8 *)mbHeader - (mbHeader->header_addr - mbHeader->load_addr),
+		(mbHeader->load_end_addr > 0 ? mbHeader->load_end_addr - mbHeader->load_addr : ldrSize));
+	if (mbHeader->bss_end_addr > 0)
+		memset((u8 *)mbHeader->load_end_addr, 0x00, mbHeader->bss_end_addr - mbHeader->load_end_addr);
+
+	/* Set up the multiboot info structure */
+	infoPtr = mbHeader->bss_end_addr;
+	if (infoPtr == 0)
+		infoPtr = mbHeader->load_addr + ldrSize;
+	mbInfo = (PMULTIBOOTINFO)((infoPtr + 3) & ~0x3);
+	memset(mbInfo, 0x00, sizeof(MULTIBOOTINFO));
+	mbInfo->flags = MB_INFO_FLAG_MEM_SIZE | MB_INFO_FLAG_BOOT_DEVICE | MB_INFO_FLAG_MEMORY_MAP;
+	/* Multiboot spec says mem_lower can't be larger than 640, which is
+	 * true for a PC. Since we're bending the multiboot rules anyway
+	 * let's pass the full megabyte */
+	mbInfo->mem_lower = 1024;
+	mbInfo->mem_upper = (xbox_ram - 1) * 1024;
+	mbInfo->boot_device = bootDev;
+	mbInfo->mmap_length = 2 * sizeof(MEMORYMAP);
+	mmap = (PMEMORYMAP)(mbInfo + 1);
+	mbInfo->mmap_addr = (u32)mmap + sizeof(u32);
+	/* Normal RAM */
+	mmap->size = sizeof(MEMORYMAP);
+	mmap->base_addr_low = 0;
+	mmap->base_addr_high = 0;
+	mmap->length_low = (xbox_ram * 1024 * 1024) - FB_SIZE;
+	mmap->length_high = 0;
+	mmap->type = 1;
+	/* Video RAM */
+	mmap++;
+	mmap->size = sizeof(MEMORYMAP);
+	/* FIXME: Framebuffer is initialized statically with FB_START in BootVgaInitialization.c
+	 * Remove this condition once the problem is fixed */
+	if (xbox_ram > 64) {
+		mmap->base_addr_low = (64 * 1024 * 1024) - FB_SIZE;
+	} else {
+		mmap->base_addr_low = (xbox_ram * 1024 * 1024) - FB_SIZE;
+	}
+	mmap->base_addr_high = 0;
+	mmap->length_low = FB_SIZE;
+	mmap->length_high = 0;
+	mmap->type = 0;
+	if (xbox_ram > 64) {
+		/* FIXME: Remove this block once framebuffer problem is fixed */
+		mmap++;
+		mmap->size = sizeof(MEMORYMAP);
+		mmap->base_addr_low = 64 * 1024 * 1024;
+		mmap->base_addr_high = 0;
+		mmap->length_low = (xbox_ram - 64) * 1024 * 1024;
+		mmap->length_high = 0;
+		mmap->type = 1;
+	}
+
+	/* Now setup the registers and jump to the multiboot entry point */
+	asm volatile (
+	"xorl %%ecx,%%ecx \n"
+	"xorl %%edx,%%edx \n"
+	"xorl %%esi,%%esi \n"
+	"xorl %%edi,%%edi \n"
+	"pushl %%eax \n"
+	"movl %0,%%eax \n"
+	"ret \n"
+	: : "i" (MULTIBOOT_BOOTLOADER_MAGIC), "b" (mbInfo), "a" (mbHeader->entry_addr));
+
+	// We are not longer here, we are already in freeldr, we never come back here
+
+	// See you again in ReactOS then
+	while (1);
+}

--- a/boot/Makefile
+++ b/boot/Makefile
@@ -1,5 +1,5 @@
 EXTRA_CFLAGS := -I$(TOPDIR)/fs/grub -I$(TOPDIR)/fs/fatx -I$(TOPDIR)/lib/crypt -I$(TOPDIR)/drivers/flash -I$(TOPDIR)/drivers/cpu -I$(TOPDIR)/drivers/ide
 
-O_TARGET := LoadLinux.o BootStartup.o BootResetAction.o BootFromDevice.o
+O_TARGET := LoadLinux.o LoadReactOS.o BootStartup.o BootResetAction.o BootFromDevice.o
 
 include $(TOPDIR)/Rules.make

--- a/boot_xbe/xbe.S
+++ b/boot_xbe/xbe.S
@@ -47,7 +47,7 @@ certificate:
 
   // title name (unicode string, 40 chars) *unimportant, but beautiful*
 unicodename:
-  .word 'L','i','n','u','x',0,0,0,0,0,0
+  .word 'X','r','o','m','w','e','l','l',0,0,0
 normalname:
   .word 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
   .word 0,0,0,0,0,0,0,0,0,0,0,0,0

--- a/fs/grub/Makefile
+++ b/fs/grub/Makefile
@@ -1,5 +1,5 @@
-EXTRA_CFLAGS := -DNO_DECOMPRESSION -DFSYS_REISERFS -DFSYS_EXT2FS -DFSYS_UFS2 -I$(TOPDIR)/fs/grub -DSTAGE1_5 -DNO_GETENV -DCROMWELL
+EXTRA_CFLAGS := -DNO_DECOMPRESSION -DFSYS_FAT -DFSYS_REISERFS -DFSYS_EXT2FS -DFSYS_UFS2 -I$(TOPDIR)/fs/grub -DSTAGE1_5 -DNO_GETENV -DCROMWELL
 
-O_TARGET := fsys_reiserfs.o fsys_ext2fs.o fsys_ufs2.o char_io.o disk_io.o
+O_TARGET := fsys_fat.o fsys_reiserfs.o fsys_ext2fs.o fsys_ufs2.o char_io.o disk_io.o
 
 include $(TOPDIR)/Rules.make

--- a/fs/grub/fat.h
+++ b/fs/grub/fat.h
@@ -1,0 +1,100 @@
+/*
+ *  GRUB  --  GRand Unified Bootloader
+ *  Copyright (C) 2001  Free Software Foundation, Inc.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+
+/*
+ *  Defines for the FAT BIOS Parameter Block (embedded in the first block
+ *  of the partition.
+ */
+
+typedef __signed__ char __s8;
+typedef unsigned char __u8;
+typedef __signed__ short __s16;
+typedef unsigned short __u16;
+typedef __signed__ int __s32;
+typedef unsigned int __u32;
+
+/* Note that some shorts are not aligned, and must therefore
+ * be declared as array of two bytes.
+ */
+struct fat_bpb {
+	__s8	ignored[3];	/* Boot strap short or near jump */
+	__s8	system_id[8];	/* Name - can be used to special case
+				   partition manager volumes */
+	__u8	bytes_per_sect[2];	/* bytes per logical sector */
+	__u8	sects_per_clust;/* sectors/cluster */
+	__u8	reserved_sects[2];	/* reserved sectors */
+	__u8	num_fats;	/* number of FATs */
+	__u8	dir_entries[2];	/* root directory entries */
+	__u8	short_sectors[2];	/* number of sectors */
+	__u8	media;		/* media code (unused) */
+	__u16	fat_length;	/* sectors/FAT */
+	__u16	secs_track;	/* sectors per track */
+	__u16	heads;		/* number of heads */
+	__u32	hidden;		/* hidden sectors (unused) */
+	__u32	long_sectors;	/* number of sectors (if short_sectors == 0) */
+
+	/* The following fields are only used by FAT32 */
+	__u32	fat32_length;	/* sectors/FAT */
+	__u16	flags;		/* bit 8: fat mirroring, low 4: active fat */
+	__u8	version[2];	/* major, minor filesystem version */
+	__u32	root_cluster;	/* first cluster in root directory */
+	__u16	info_sector;	/* filesystem info sector */
+	__u16	backup_boot;	/* backup boot sector */
+	__u16	reserved2[6];	/* Unused */
+};
+
+#define FAT_CVT_U16(bytarr) (* (__u16*)(bytarr))
+
+/*
+ *  Defines how to differentiate a 12-bit and 16-bit FAT.
+ */
+
+#define FAT_MAX_12BIT_CLUST       4087	/* 4085 + 2 */
+
+/*
+ *  Defines for the file "attribute" byte
+ */
+
+#define FAT_ATTRIB_OK_MASK        0x37
+#define FAT_ATTRIB_NOT_OK_MASK    0xC8
+#define FAT_ATTRIB_DIR            0x10
+#define FAT_ATTRIB_LONGNAME       0x0F
+
+/*
+ *  Defines for FAT directory entries
+ */
+
+#define FAT_DIRENTRY_LENGTH       32
+
+#define FAT_DIRENTRY_ATTRIB(entry) \
+  (*((unsigned char *) (entry+11)))
+#define FAT_DIRENTRY_VALID(entry) \
+  ( ((*((unsigned char *) entry)) != 0) \
+    && ((*((unsigned char *) entry)) != 0xE5) \
+    && !(FAT_DIRENTRY_ATTRIB(entry) & FAT_ATTRIB_NOT_OK_MASK) )
+#define FAT_DIRENTRY_FIRST_CLUSTER(entry) \
+  ((*((unsigned short *) (entry+26)))+(*((unsigned short *) (entry+20)) << 16))
+#define FAT_DIRENTRY_FILELENGTH(entry) \
+  (*((unsigned long *) (entry+28)))
+
+#define FAT_LONGDIR_ID(entry) \
+  (*((unsigned char *) (entry)))
+#define FAT_LONGDIR_ALIASCHECKSUM(entry) \
+  (*((unsigned char *) (entry+13)))

--- a/fs/grub/fsys_fat.c
+++ b/fs/grub/fsys_fat.c
@@ -1,0 +1,488 @@
+/*
+ *  GRUB  --  GRand Unified Bootloader
+ *  Copyright (C) 2000,2001,2005   Free Software Foundation, Inc.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifdef FSYS_FAT
+
+#include "shared.h"
+#include "filesys.h"
+#include "fat.h"
+
+struct fat_superblock 
+{
+  int fat_offset;
+  int fat_length;
+  int fat_size;
+  int root_offset;
+  int root_max;
+  int data_offset;
+  
+  int num_sectors;
+  int num_clust;
+  int clust_eof_marker;
+  int sects_per_clust;
+  int sectsize_bits;
+  int clustsize_bits;
+  int root_cluster;
+  
+  int cached_fat;
+  int file_cluster;
+  int current_cluster_num;
+  int current_cluster;
+};
+
+/* pointer(s) into filesystem info buffer for DOS stuff */
+#define FAT_SUPER ( (struct fat_superblock *) \
+ 		    ( FSYS_BUF + 32256) )/* 512 bytes long */
+#define FAT_BUF   ( FSYS_BUF + 30208 )	/* 4 sector FAT buffer */
+#define NAME_BUF  ( FSYS_BUF + 29184 )	/* Filename buffer (833 bytes) */
+
+#define FAT_CACHE_SIZE 2048
+
+static __inline__ unsigned long
+log2 (unsigned long word)
+{
+  __asm__ ("bsfl %1,%0"
+	   : "=r" (word)
+	   : "r" (word));
+  return word;
+}
+
+int
+fat_mount (void)
+{
+  struct fat_bpb bpb;
+  __u32 magic, first_fat;
+  
+  /* Check partition type for harddisk */
+  if (((current_drive & 0x80) || (current_slice != 0))
+      && ! IS_PC_SLICE_TYPE_FAT (current_slice)
+      && (! IS_PC_SLICE_TYPE_BSD_WITH_FS (current_slice, FS_MSDOS)))
+    return 0;
+  
+  /* Read bpb */
+  if (! devread (0, 0, sizeof (bpb), (char *) &bpb))
+    return 0;
+
+  /* Check if the number of sectors per cluster is zero here, to avoid
+     zero division.  */
+  if (bpb.sects_per_clust == 0)
+    return 0;
+  
+  FAT_SUPER->sectsize_bits = log2 (FAT_CVT_U16 (bpb.bytes_per_sect));
+  FAT_SUPER->clustsize_bits
+    = FAT_SUPER->sectsize_bits + log2 (bpb.sects_per_clust);
+  
+  /* Fill in info about super block */
+  FAT_SUPER->num_sectors = FAT_CVT_U16 (bpb.short_sectors) 
+    ? FAT_CVT_U16 (bpb.short_sectors) : bpb.long_sectors;
+  
+  /* FAT offset and length */
+  FAT_SUPER->fat_offset = FAT_CVT_U16 (bpb.reserved_sects);
+  FAT_SUPER->fat_length = 
+    bpb.fat_length ? bpb.fat_length : bpb.fat32_length;
+  
+  /* Rootdir offset and length for FAT12/16 */
+  FAT_SUPER->root_offset = 
+    FAT_SUPER->fat_offset + bpb.num_fats * FAT_SUPER->fat_length;
+  FAT_SUPER->root_max = FAT_DIRENTRY_LENGTH * FAT_CVT_U16(bpb.dir_entries);
+  
+  /* Data offset and number of clusters */
+  FAT_SUPER->data_offset = 
+    FAT_SUPER->root_offset
+    + ((FAT_SUPER->root_max - 1) >> FAT_SUPER->sectsize_bits) + 1;
+  FAT_SUPER->num_clust = 
+    2 + ((FAT_SUPER->num_sectors - FAT_SUPER->data_offset) 
+	 / bpb.sects_per_clust);
+  FAT_SUPER->sects_per_clust = bpb.sects_per_clust;
+  
+  if (!bpb.fat_length)
+    {
+      /* This is a FAT32 */
+      if (FAT_CVT_U16(bpb.dir_entries))
+ 	return 0;
+      
+      if (bpb.flags & 0x0080)
+	{
+	  /* FAT mirroring is disabled, get active FAT */
+	  int active_fat = bpb.flags & 0x000f;
+	  if (active_fat >= bpb.num_fats)
+	    return 0;
+	  FAT_SUPER->fat_offset += active_fat * FAT_SUPER->fat_length;
+	}
+      
+      FAT_SUPER->fat_size = 8;
+      FAT_SUPER->root_cluster = bpb.root_cluster;
+
+      /* Yes the following is correct.  FAT32 should be called FAT28 :) */
+      FAT_SUPER->clust_eof_marker = 0xffffff8;
+    } 
+  else 
+    {
+      if (!FAT_SUPER->root_max)
+ 	return 0;
+      
+      FAT_SUPER->root_cluster = -1;
+      if (FAT_SUPER->num_clust > FAT_MAX_12BIT_CLUST) 
+	{
+	  FAT_SUPER->fat_size = 4;
+	  FAT_SUPER->clust_eof_marker = 0xfff8;
+	} 
+      else
+	{
+	  FAT_SUPER->fat_size = 3;
+	  FAT_SUPER->clust_eof_marker = 0xff8;
+	}
+    }
+
+  /* Now do some sanity checks */
+  
+  if (FAT_CVT_U16(bpb.bytes_per_sect) != (1 << FAT_SUPER->sectsize_bits)
+      || FAT_CVT_U16(bpb.bytes_per_sect) != SECTOR_SIZE
+      || bpb.sects_per_clust != (1 << (FAT_SUPER->clustsize_bits
+ 				       - FAT_SUPER->sectsize_bits))
+      || FAT_SUPER->num_clust <= 2
+      || (FAT_SUPER->fat_size * FAT_SUPER->num_clust / (2 * SECTOR_SIZE)
+ 	  > FAT_SUPER->fat_length))
+    return 0;
+  
+  /* kbs: Media check on first FAT entry [ported from PUPA] */
+
+  if (!devread(FAT_SUPER->fat_offset, 0,
+               sizeof(first_fat), (char *)&first_fat))
+    return 0;
+
+  if (FAT_SUPER->fat_size == 8)
+    {
+      first_fat &= 0x0fffffff;
+      magic = 0x0fffff00;
+    }
+  else if (FAT_SUPER->fat_size == 4)
+    {
+      first_fat &= 0x0000ffff;
+      magic = 0xff00;
+    }
+  else
+    {
+      first_fat &= 0x00000fff;
+      magic = 0x0f00;
+    }
+
+  /* Ignore the 3rd bit, because some BIOSes assigns 0xF0 to the media
+     descriptor, even if it is a so-called superfloppy (e.g. an USB key).
+     The check may be too strict for this kind of stupid BIOSes, as
+     they overwrite the media descriptor.  */
+  if ((first_fat | 0x8) != (magic | bpb.media | 0x8))
+    return 0;
+
+  FAT_SUPER->cached_fat = - 2 * FAT_CACHE_SIZE;
+  return 1;
+}
+
+int
+fat_read (char *buf, int len)
+{
+  int logical_clust;
+  int offset;
+  int ret = 0;
+  int size;
+  
+  if (FAT_SUPER->file_cluster < 0)
+    {
+      /* root directory for fat16 */
+      size = FAT_SUPER->root_max - filepos;
+      if (size > len)
+ 	size = len;
+      if (!devread(FAT_SUPER->root_offset, filepos, size, buf))
+ 	return 0;
+      filepos += size;
+      return size;
+    }
+  
+  logical_clust = filepos >> FAT_SUPER->clustsize_bits;
+  offset = (filepos & ((1 << FAT_SUPER->clustsize_bits) - 1));
+  if (logical_clust < FAT_SUPER->current_cluster_num)
+    {
+      FAT_SUPER->current_cluster_num = 0;
+      FAT_SUPER->current_cluster = FAT_SUPER->file_cluster;
+    }
+  
+  while (len > 0)
+    {
+      int sector;
+      while (logical_clust > FAT_SUPER->current_cluster_num)
+	{
+	  /* calculate next cluster */
+	  int fat_entry = 
+	    FAT_SUPER->current_cluster * FAT_SUPER->fat_size;
+	  int next_cluster;
+	  int cached_pos = (fat_entry - FAT_SUPER->cached_fat);
+	  
+	  if (cached_pos < 0 || 
+	      (cached_pos + FAT_SUPER->fat_size) > 2*FAT_CACHE_SIZE)
+	    {
+	      FAT_SUPER->cached_fat = (fat_entry & ~(2*SECTOR_SIZE - 1));
+	      cached_pos = (fat_entry - FAT_SUPER->cached_fat);
+	      sector = FAT_SUPER->fat_offset
+		+ FAT_SUPER->cached_fat / (2*SECTOR_SIZE);
+	      if (!devread (sector, 0, FAT_CACHE_SIZE, (char*) FAT_BUF))
+		return 0;
+	    }
+	  next_cluster = * (unsigned long *) (FAT_BUF + (cached_pos >> 1));
+	  if (FAT_SUPER->fat_size == 3)
+	    {
+	      if (cached_pos & 1)
+		next_cluster >>= 4;
+	      next_cluster &= 0xFFF;
+	    }
+	  else if (FAT_SUPER->fat_size == 4)
+	    next_cluster &= 0xFFFF;
+	  
+	  if (next_cluster >= FAT_SUPER->clust_eof_marker)
+	    return ret;
+	  if (next_cluster < 2 || next_cluster >= FAT_SUPER->num_clust)
+	    {
+	      errnum = ERR_FSYS_CORRUPT;
+	      return 0;
+	    }
+	  
+	  FAT_SUPER->current_cluster = next_cluster;
+	  FAT_SUPER->current_cluster_num++;
+	}
+      
+      sector = FAT_SUPER->data_offset +
+	((FAT_SUPER->current_cluster - 2) << (FAT_SUPER->clustsize_bits
+ 					      - FAT_SUPER->sectsize_bits));
+      size = (1 << FAT_SUPER->clustsize_bits) - offset;
+      if (size > len)
+	size = len;
+      
+      disk_read_func = disk_read_hook;
+      
+      devread(sector, offset, size, buf);
+      
+      disk_read_func = NULL;
+      
+      len -= size;
+      buf += size;
+      ret += size;
+      filepos += size;
+      logical_clust++;
+      offset = 0;
+    }
+  return errnum ? 0 : ret;
+}
+
+int
+fat_dir (char *dirname)
+{
+  char *rest, ch, dir_buf[FAT_DIRENTRY_LENGTH];
+  char *filename = (char *) NAME_BUF;
+  int attrib = FAT_ATTRIB_DIR;
+#ifndef STAGE1_5
+  int do_possibilities = 0;
+#endif
+  
+  /* XXX I18N:
+   * the positions 2,4,6 etc are high bytes of a 16 bit unicode char 
+   */
+  static unsigned char longdir_pos[] = 
+  { 1, 3, 5, 7, 9, 14, 16, 18, 20, 22, 24, 28, 30 };
+  int slot = -2;
+  int alias_checksum = -1;
+  
+  FAT_SUPER->file_cluster = FAT_SUPER->root_cluster;
+  filepos = 0;
+  FAT_SUPER->current_cluster_num = MAXINT;
+  
+  /* main loop to find desired directory entry */
+ loop:
+  
+  /* if we have a real file (and we're not just printing possibilities),
+     then this is where we want to exit */
+  
+  if (!*dirname || isspace (*dirname))
+    {
+      if (attrib & FAT_ATTRIB_DIR)
+	{
+	  errnum = ERR_BAD_FILETYPE;
+	  return 0;
+	}
+      
+      return 1;
+    }
+  
+  /* continue with the file/directory name interpretation */
+  
+  while (*dirname == '/')
+    dirname++;
+  
+  if (!(attrib & FAT_ATTRIB_DIR))
+    {
+      errnum = ERR_BAD_FILETYPE;
+      return 0;
+    }
+  /* Directories don't have a file size */
+  filemax = MAXINT;
+  
+  for (rest = dirname; (ch = *rest) && !isspace (ch) && ch != '/'; rest++);
+  
+  *rest = 0;
+  
+# ifndef STAGE1_5
+  if (print_possibilities && ch != '/')
+    do_possibilities = 1;
+# endif
+  
+  while (1)
+    {
+      if (fat_read (dir_buf, FAT_DIRENTRY_LENGTH) != FAT_DIRENTRY_LENGTH
+	  || dir_buf[0] == 0)
+	{
+	  if (!errnum)
+	    {
+# ifndef STAGE1_5
+	      if (print_possibilities < 0)
+		{
+#if 0
+		  putchar ('\n');
+#endif
+		  return 1;
+		}
+# endif /* STAGE1_5 */
+	      
+	      errnum = ERR_FILE_NOT_FOUND;
+	      *rest = ch;
+	    }
+	  
+	  return 0;
+	}
+      
+      if (FAT_DIRENTRY_ATTRIB (dir_buf) == FAT_ATTRIB_LONGNAME)
+	{
+	  /* This is a long filename.  The filename is build from back
+	   * to front and may span multiple entries.  To bind these
+	   * entries together they all contain the same checksum over
+	   * the short alias.
+	   *
+	   * The id field tells if this is the first entry (the last
+	   * part) of the long filename, and also at which offset this
+	   * belongs.
+	   *
+	   * We just write the part of the long filename this entry
+	   * describes and continue with the next dir entry.
+	   */
+	  int i, offset;
+	  unsigned char id = FAT_LONGDIR_ID(dir_buf);
+	  
+	  if ((id & 0x40)) 
+	    {
+	      id &= 0x3f;
+	      slot = id;
+	      filename[slot * 13] = 0;
+	      alias_checksum = FAT_LONGDIR_ALIASCHECKSUM(dir_buf);
+	    } 
+	  
+	  if (id != slot || slot == 0
+	      || alias_checksum != FAT_LONGDIR_ALIASCHECKSUM(dir_buf))
+	    {
+	      alias_checksum = -1;
+	      continue;
+	    }
+	  
+	  slot--;
+	  offset = slot * 13;
+	  
+	  for (i=0; i < 13; i++)
+	    filename[offset+i] = dir_buf[longdir_pos[i]];
+	  continue;
+	}
+      
+      if (!FAT_DIRENTRY_VALID (dir_buf))
+	continue;
+      
+      if (alias_checksum != -1 && slot == 0)
+	{
+	  int i;
+	  unsigned char sum;
+	  
+	  slot = -2;
+	  for (sum = 0, i = 0; i< 11; i++)
+	    sum = ((sum >> 1) | (sum << 7)) + dir_buf[i];
+	  
+	  if (sum == alias_checksum)
+	    {
+# ifndef STAGE1_5
+	      if (do_possibilities)
+		goto print_filename;
+# endif /* STAGE1_5 */
+	      
+	      if (substring (dirname, filename) == 0)
+		break;
+	    }
+	}
+      
+      /* XXX convert to 8.3 filename format here */
+      {
+	int i, j, c;
+	
+	for (i = 0; i < 8 && (c = filename[i] = tolower (dir_buf[i]))
+	       && !isspace (c); i++);
+	
+	filename[i++] = '.';
+	
+	for (j = 0; j < 3 && (c = filename[i + j] = tolower (dir_buf[8 + j]))
+	       && !isspace (c); j++);
+	
+	if (j == 0)
+	  i--;
+	
+	filename[i + j] = 0;
+      }
+      
+# ifndef STAGE1_5
+      if (do_possibilities)
+	{
+	print_filename:
+	  if (substring (dirname, filename) <= 0)
+	    {
+	      if (print_possibilities > 0)
+		print_possibilities = -print_possibilities;
+	      print_a_completion (filename);
+	    }
+	  continue;
+	}
+# endif /* STAGE1_5 */
+      
+      if (substring (dirname, filename) == 0)
+	break;
+    }
+  
+  *(dirname = rest) = ch;
+  
+  attrib = FAT_DIRENTRY_ATTRIB (dir_buf);
+  filemax = FAT_DIRENTRY_FILELENGTH (dir_buf);
+  filepos = 0;
+  FAT_SUPER->file_cluster = FAT_DIRENTRY_FIRST_CLUSTER (dir_buf);
+  FAT_SUPER->current_cluster_num = MAXINT;
+  
+  /* go back to main loop at top of function */
+  goto loop;
+}
+
+#endif /* FSYS_FAT */

--- a/include/memory_layout.h
+++ b/include/memory_layout.h
@@ -3,7 +3,7 @@
 
 /* a retail Xbox has 64 MB of RAM */
 #define RAMSIZE (64 * 1024*1024)
-/* parameters for the kernel have to be here */
+/* parameters for the Linux kernel have to be here */
 #define KERNEL_SETUP   0x90000
 #define KERNEL_HDR_SIZE (4 * 1024)
 /* command line must not be overwritten, place it in unused setup area */
@@ -20,14 +20,18 @@
 #define INITRD_START       KERNEL_PM_CODE_END
 #define MAX_INITRD_END     0x02A00000
 
+#define MAX_KERNEL_SIZE    (KERNEL_PM_CODE_END - KERNEL_PM_CODE)
+#define MAX_INITRD_SIZE    (MAX_INITRD_END - INITRD_START)
+
+/* parameters for ReactOS have to be here */
+#define FREELDR_LOAD_AREA  (u8 *)0x00001000
+#define FREELDR_MAX_SIZE   0x80000
+
 #define MEMORYMANAGERSTART MAX_INITRD_END
 #define MEMORYMANAGEREND   0x039FFFFF
+#define MEMORYMANAGERSIZE  (MEMORYMANAGEREND - MEMORYMANAGERSTART)
 
 #define STACK_TOP 0x03C00000
-
-#define MAX_KERNEL_SIZE    (KERNEL_PM_CODE_END - KERNEL_PM_CODE)
-#define MEMORYMANAGERSIZE  (MEMORYMANAGEREND - MEMORYMANAGERSTART)
-#define MAX_INITRD_SIZE    (MAX_INITRD_END - INITRD_START)
 
 /* the size of the framebuffer (defaults to 4 MB) */
 #define FB_SIZE 0x00400000

--- a/lib/misc/BootParser.h
+++ b/lib/misc/BootParser.h
@@ -16,6 +16,7 @@ enum BootTypes {
 
 enum BootSystems {
 	SYS_LINUX,
+	SYS_REACTOS,
 };
 
 typedef struct OPTLINUX {
@@ -23,6 +24,12 @@ typedef struct OPTLINUX {
 	char szInitrd[MAX_LINE];
 	char szAppend[MAX_LINE];
 } OPTLINUX;
+
+typedef struct OPTMULTIBOOT {
+	u8* pBuffer;
+	u32 uBufferSize;
+	u32 uBootDevice;
+} OPTMULTIBOOT;
 
 typedef struct CONFIGENTRY {
 	int  drive;
@@ -34,6 +41,7 @@ typedef struct CONFIGENTRY {
 	char szPath[MAX_LINE];
 	union {
 		struct OPTLINUX Linux;
+		struct OPTMULTIBOOT Multiboot;
 	} opt;
 	struct CONFIGENTRY *previousConfigEntry;
 	struct CONFIGENTRY *nextConfigEntry;


### PR DESCRIPTION
Backport ReactOS boot support commits, including fix in the GRUB wrapper code.

Third stage of three towards ReactOS boot support, fixes #17.

Important notes:
- `fsys_fat.c` and `fat.h` are imported as is from GRUB project
- I placed some `FIXME` comments regarding side problems, and I will convert them to issues later