### PR TITLE
xdecode: Port to C99 for portability

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,4 +1,4 @@
 CC := gcc
 
 all:
-	${CC} -pedantic -Wall -o xdecode xdecode.c
+	${CC} -std=c99 -pedantic -Wall -o xdecode xdecode.c

--- a/tools/README
+++ b/tools/README
@@ -1,4 +1,4 @@
-Xbox Xcode decompiler - David Pye, 2006 (c) dmp@davidmpye.dyndns.org
+Xbox Xcode decompiler
 
 This tool is available under the GNU GPL - please see source
 file boilerplate for details.


### PR DESCRIPTION
This should make the `xdecode` utility work on x64.

I did look at the disassembly and it looked fine, but I did not try to re-assembling the dumped x-codes (probably not necessary either).