### PR TITLE
boot: Set LED mode to 'auto'

### DIFF
--- a/boot/LoadLinux.c
+++ b/boot/LoadLinux.c
@@ -343,8 +343,8 @@ void startLinux(void* initrdStart, unsigned long initrdSize, const char* appendL
 	BootIdeSetTransferMode(0, 0x40 | nAta);
 	BootIdeSetTransferMode(1, 0x40 | nAta);
 
-	// orange, people seem to like that colour
-	setLED("oooo");
+	// Set the LED to auto-mode
+	resetLED();
 	         
 	// Set framebuffer address to final location (for vesafb driver)
 	(*(unsigned int*)0xFD600800) = (0xf0000000 | ((xbox_ram*0x100000) - FB_SIZE));

--- a/boot/LoadReactOS.c
+++ b/boot/LoadReactOS.c
@@ -345,8 +345,8 @@ void startReactOS(PMULTIBOOTHEADER mbHeader, u32 loaderSize, u32 bootDevice) {
 	BootIdeSetTransferMode(0, 0x40 | nAta);
 	BootIdeSetTransferMode(1, 0x40 | nAta);
 
-	/* orange, people seem to like that colour */
-	setLED("oooo");
+	/* Set the LED to auto-mode */
+	resetLED();
 
 	/* Do not update framebuffer address, as ReactOS video drivers reuse it as is,
 	 * and do not perform video hardware initialization. See also FIXME below. */

--- a/boot_rom/2bPicResponseAction.c
+++ b/boot_rom/2bPicResponseAction.c
@@ -151,3 +151,9 @@ extern int I2cSetFrontpanelLed(u8 b)
 	return ERR_SUCCESS;
 }
 
+extern int I2cResetFrontpanelLed(void)
+{
+	I2CTransmitWord( 0x10, 0x700);
+	return ERR_SUCCESS;
+}
+

--- a/boot_rom/2bload.h
+++ b/boot_rom/2bload.h
@@ -81,6 +81,7 @@ static __inline u32 IoInputDword(u16 wAds) {
 int BootPerformPicChallengeResponseAction(void);
 // LED control (see associated enum above)
 int I2cSetFrontpanelLed(u8 b);
+int I2cResetFrontpanelLed(void);
 
 ////////// BootResetActions.c
 

--- a/drivers/pci/i2cio.c
+++ b/drivers/pci/i2cio.c
@@ -198,6 +198,14 @@ extern int I2cSetFrontpanelLed(u8 b)
 	return ERR_SUCCESS;
 }
 
+extern int I2cResetFrontpanelLed(void)
+{
+	I2CTransmitWord( 0x10, 0x700);
+
+
+	return ERR_SUCCESS;
+}
+
 bool I2CGetTemperature(int * pnLocalTemp, int * pExternalTemp)
 {
 	*pnLocalTemp=I2CTransmitByteGetReturn(0x4c, 0x01);

--- a/include/boot.h
+++ b/include/boot.h
@@ -206,6 +206,7 @@ void BootPciInterruptEnable(void);
 int BootPerformPicChallengeResponseAction(void);
 	// LED control (see associated enum above)
 int I2cSetFrontpanelLed(u8 b);
+int I2cResetFrontpanelLed(void);
 
 void bprintf(const char *fmt, ...);
 

--- a/lib/misc/LED.c
+++ b/lib/misc/LED.c
@@ -50,3 +50,7 @@ void setLED(char *pattern) {
 	}
 	I2cSetFrontpanelLed(((r<<4) & 0xF0) + (g & 0xF));
 }
+
+void resetLED(void) {
+	I2cResetFrontpanelLed();
+}


### PR DESCRIPTION
Set LED mode to auto, as a solid orange light typically indicates having some kind of problem.

Closes #29 