### PR TITLE
Properly declare some UI related functions to fix warnings

### DIFF
--- a/drivers/pci/BootInterrupts.c
+++ b/drivers/pci/BootInterrupts.c
@@ -110,7 +110,7 @@ const ISR_PREP isrprep[] = {
 	{ 0, 0 }
 };
 
-u32 GetTimerTicks() {
+u32 GetTimerTicks(void) {
 	return IoInputDword(TIMER_IO);
 }
 
@@ -245,12 +245,12 @@ void BootInterruptsWriteIdt() {
 // ISRs
 
 
-void DVDTrayEject()
+void DVDTrayEject(void)
 {
 	I2CTransmitWord(0x10, 0x0c00);
 }
 
-void DVDTrayClose()
+void DVDTrayClose(void)
 {
 	I2CTransmitWord(0x10, 0x0c01);
 }

--- a/include/boot.h
+++ b/include/boot.h
@@ -262,9 +262,9 @@ u8 PciReadByte(unsigned int bus, unsigned int dev, unsigned int func, unsigned i
 u32 PciWriteDword(unsigned int bus, unsigned int dev, unsigned int func, unsigned int reg_off, u32 dw);
 u32 PciReadDword(unsigned int bus, unsigned int dev, unsigned int func, unsigned int reg_off);
 
-void LpcEnterConfiguration();
-void LpcExitConfiguration();
-int LpcGetSerialState();
+void LpcEnterConfiguration(void);
+void LpcExitConfiguration(void);
+int LpcGetSerialState(void);
 void LpcSetSerialState(int enable);
 
 ///////// BootPerformPicChallengeResponseAction.c

--- a/menu/actions/MenuActions.c
+++ b/menu/actions/MenuActions.c
@@ -20,7 +20,6 @@
 #include "cpu.h"
 #include "VideoInitialization.h"
 #include "TextMenu.h"
-TEXTMENU *TextMenuInit(void);
 
 void AdvancedMenu(void *textmenu) {
 	TextMenu((TEXTMENU*)textmenu, NULL);
@@ -101,7 +100,7 @@ void BootMenuEntry(void *entry) {
 }
 
 void DrawChildTextMenu(void *menu) {
-	TextMenu((TEXTMENU*)menu);
+	TextMenu((TEXTMENU*)menu, NULL);
 }
 
 #ifdef ETHERBOOT 

--- a/menu/iconmenu/IconMenuInit.c
+++ b/menu/iconmenu/IconMenuInit.c
@@ -14,6 +14,7 @@
 #include "BootIde.h"
 #include "IconMenu.h"
 #include "MenuActions.h"
+#include "TextMenu.h"
 
 void InitFatXIcons(void);
 void InitNativeIcons(void);

--- a/menu/textmenu/TextMenu.c
+++ b/menu/textmenu/TextMenu.c
@@ -8,9 +8,8 @@
  ***************************************************************************/
 
 #include "TextMenu.h"
-int breakOutOfMenu=0;
 
-void TextMenuDraw(TEXTMENU *menu, TEXTMENUITEM *firstVisibleMenuItem, TEXTMENUITEM *selectedItem);
+int breakOutOfMenu = 0;
 
 void TextMenuAddItem(TEXTMENU *menu, TEXTMENUITEM *newMenuItem) {
 	TEXTMENUITEM *menuItem = menu->firstMenuItem;

--- a/menu/textmenu/TextMenu.h
+++ b/menu/textmenu/TextMenu.h
@@ -47,4 +47,15 @@ typedef struct TEXTMENU {
 	TEXTMENUITEM* firstMenuItem;
 } TEXTMENU;
 
+void TextMenu(TEXTMENU *menu, TEXTMENUITEM *selectedItem);
+void TextMenuAddItem(TEXTMENU *menu, TEXTMENUITEM *newMenuItem);
+void TextMenuDraw(TEXTMENU *menu, TEXTMENUITEM *firstVisibleMenuItem, TEXTMENUITEM *selectedItem);
+
+TEXTMENU *TextMenuInit(void);
+TEXTMENU *FlashMenuInit(void);
+TEXTMENU *HddMenuInit(void);
+TEXTMENU *PhyMenuInit(void);
+TEXTMENU *ResetMenuInit(void);
+TEXTMENU *VideoMenuInit(void);
+
 #endif


### PR DESCRIPTION
This also indirectly fixes an issue with 3rd level menu's having text not be highlighted.

This was meant to fix (#9) however it became clear that the code base has a lot more problems especially when turning on higher levels of warnings.
