### PR TITLE
build: Suppress invocation echo of gcc and linker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,12 +183,12 @@ all: clean resources $(BOOT_ETH_SUBDIRS) cromsubdirs xromwell.xbe vmlboot $(BOOT
 ifeq ($(ETHERBOOT), yes)
 ethsubdirs: $(patsubst %, _dir_%, $(ETH_SUBDIRS))
 $(patsubst %, _dir_%, $(ETH_SUBDIRS)) : dummy
-	$(MAKE) CFLAGS="$(ETH_CFLAGS)" -C $(patsubst _dir_%, %, $@)
+	@$(MAKE) CFLAGS="$(ETH_CFLAGS)" -C $(patsubst _dir_%, %, $@)
 endif
 
 cromsubdirs: $(patsubst %, _dir_%, $(SUBDIRS))
 $(patsubst %, _dir_%, $(SUBDIRS)) : dummy
-	$(MAKE) CFLAGS="$(CFLAGS) $(CROM_CFLAGS)" -C $(patsubst _dir_%, %, $@)
+	@$(MAKE) CFLAGS="$(CFLAGS) $(CROM_CFLAGS)" -C $(patsubst _dir_%, %, $@)
 
 dummy:
 
@@ -216,34 +216,34 @@ clean:
 	mkdir -p $(TOPDIR)/bin
 
 obj/image-crom.bin:
-	${LD} -o obj/image-crom.elf ${OBJECTS-CROM} ${RESOURCES} ${LDFLAGS-ROM}
-	${OBJCOPY} --output-target=binary --strip-all obj/image-crom.elf $@
+	@${LD} -o obj/image-crom.elf ${OBJECTS-CROM} ${RESOURCES} ${LDFLAGS-ROM}
+	@${OBJCOPY} --output-target=binary --strip-all obj/image-crom.elf $@
 
 vmlboot: ${OBJECTS-VML}
-	${LD} -o $(TOPDIR)/obj/vmlboot.elf ${OBJECTS-VML} ${LDFLAGS-VMLBOOT}
-	${OBJCOPY} --output-target=binary --strip-all $(TOPDIR)/obj/vmlboot.elf $(TOPDIR)/boot_vml/disk/$@
+	@${LD} -o $(TOPDIR)/obj/vmlboot.elf ${OBJECTS-VML} ${LDFLAGS-VMLBOOT}
+	@${OBJCOPY} --output-target=binary --strip-all $(TOPDIR)/obj/vmlboot.elf $(TOPDIR)/boot_vml/disk/$@
 
 ifeq ($(ETHERBOOT), yes)
 boot_eth/ethboot: ${OBJECTS-ETH} obj/image-crom.bin
-	${LD} -o obj/ethboot.elf ${OBJECTS-ETH} -b binary obj/image-crom.bin ${LDFLAGS-ETHBOOT}
-	${OBJCOPY} --output-target=binary --strip-all obj/ethboot.elf obj/ethboot.bin
+	@${LD} -o obj/ethboot.elf ${OBJECTS-ETH} -b binary obj/image-crom.bin ${LDFLAGS-ETHBOOT}
+	@${OBJCOPY} --output-target=binary --strip-all obj/ethboot.elf obj/ethboot.bin
 	perl -I boot_eth boot_eth/mknbi.pl --output=$@ obj/ethboot.bin
 endif
 
 xromwell.xbe: ${OBJECTS-XBE}
-	${LD} -o $(TOPDIR)/obj/xbeboot.elf ${OBJECTS-XBE} ${LDFLAGS-XBEBOOT}
-	${OBJCOPY} --output-target=binary --strip-all $(TOPDIR)/obj/xbeboot.elf $(TOPDIR)/xbe/$@
+	@${LD} -o $(TOPDIR)/obj/xbeboot.elf ${OBJECTS-XBE} ${LDFLAGS-XBEBOOT}
+	@${OBJCOPY} --output-target=binary --strip-all $(TOPDIR)/obj/xbeboot.elf $(TOPDIR)/xbe/$@
 
 cromwell.bin:
-	${LD} -o $(TOPDIR)/obj/2lbimage.elf ${OBJECTS-ROMBOOT} ${LDFLAGS-ROMBOOT}
-	${OBJCOPY} --output-target=binary --strip-all $(TOPDIR)/obj/2lbimage.elf $(TOPDIR)/obj/2blimage.bin
+	@${LD} -o $(TOPDIR)/obj/2lbimage.elf ${OBJECTS-ROMBOOT} ${LDFLAGS-ROMBOOT}
+	@${OBJCOPY} --output-target=binary --strip-all $(TOPDIR)/obj/2lbimage.elf $(TOPDIR)/obj/2blimage.bin
 
 # This is a local executable, so don't use a cross compiler...
 bin/imagebld: lib/imagebld/imagebld.c lib/crypt/sha1.c lib/crypt/md5.c
-	gcc -m32 -Ilib/crypt -o bin/sha1.o -c lib/crypt/sha1.c
-	gcc -m32 -Ilib/crypt -o bin/md5.o -c lib/crypt/md5.c
-	gcc -m32 -Ilib/crypt -o bin/imagebld.o -c lib/imagebld/imagebld.c
-	gcc -m32 -o bin/imagebld bin/imagebld.o bin/sha1.o bin/md5.o
+	@gcc -m32 -Ilib/crypt -o bin/sha1.o -c lib/crypt/sha1.c
+	@gcc -m32 -Ilib/crypt -o bin/md5.o -c lib/crypt/md5.c
+	@gcc -m32 -Ilib/crypt -o bin/imagebld.o -c lib/imagebld/imagebld.c
+	@gcc -m32 -o bin/imagebld bin/imagebld.o bin/sha1.o bin/md5.o
 	
 imagecompress: obj/image-crom.bin bin/imagebld
 	cp obj/image-crom.bin obj/image-crom.bin.tmp

--- a/Rules.make
+++ b/Rules.make
@@ -20,7 +20,7 @@ comma	:= ,
 # Get things started.
 #
 first_rule: sub_dirs
-	$(MAKE) all_targets
+	@$(MAKE) all_targets
 
 SUB_DIRS	:= $(subdir)
 
@@ -29,13 +29,13 @@ SUB_DIRS	:= $(subdir)
 #
 
 BootPerformPicChallengeResponseAction.o: BootPerformPicChallengeResponseAction.c
-	$(CC) $(CFLAGSBR) $(INCLUDE) -o $(TOPDIR)/obj/$@ -c $<
+	@$(CC) $(CFLAGSBR) $(INCLUDE) -o $(TOPDIR)/obj/$@ -c $<
 
 %.o     : %.c
-	$(CC) $(CFLAGS) -no-pie $(EXTRA_CFLAGS) -o $(TOPDIR)/obj/$@ -c $<
+	@$(CC) $(CFLAGS) -no-pie $(EXTRA_CFLAGS) -o $(TOPDIR)/obj/$@ -c $<
 
 %.o     : %.S
-	$(CC) -m32 -no-pie -DASSEMBLER $(CFLAGS)  -o $(TOPDIR)/obj/$@ -c $<
+	@$(CC) -m32 -no-pie -DASSEMBLER $(CFLAGS)  -o $(TOPDIR)/obj/$@ -c $<
 
 all_targets: $(O_TARGET)
 
@@ -49,7 +49,7 @@ sub_dirs: dummy $(subdir-list)
 
 ifdef SUB_DIRS
 $(subdir-list) : dummy
-	$(MAKE) -C $(patsubst _subdir_%,%,$@)
+	@$(MAKE) -C $(patsubst _subdir_%,%,$@)
 endif
 
 #

--- a/boot_eth/Makefile
+++ b/boot_eth/Makefile
@@ -4,6 +4,6 @@ O_TARGET :=  eth_Startup.o
 eth_Startup.o:
 
 %.o     : %.S
-	${CC} -DASSEMBLER ${CFLAGS} -o $@ -c $<
+	@${CC} -DASSEMBLER ${CFLAGS} -o $@ -c $<
 
 #include $(TOPDIR)/Rules.make

--- a/boot_vml/Makefile
+++ b/boot_vml/Makefile
@@ -4,6 +4,6 @@ O_TARGET := vml_Startup.o
 vml_Startup.o:
 
 %.o     : %.S
-	${CC} -DASSEMBLER ${CFLAGS} -o $@ -c $<
+	@${CC} -DASSEMBLER ${CFLAGS} -o $@ -c $<
 
 #include $(TOPDIR)/Rules.make

--- a/boot_xbe/Makefile
+++ b/boot_xbe/Makefile
@@ -4,5 +4,5 @@ O_TARGET := xbeboot.o
 xbeboot.o:
 
 %.o     : %.S
-	${CC} -DASSEMBLER ${CFLAGS} -o $@ -c $<
+	@${CC} -DASSEMBLER ${CFLAGS} -o $@ -c $<
 


### PR DESCRIPTION
Much much cleaner output, this doesn't attempt to remove echos such as `make[2]: Leaving directory '/home/wsl/Test/cromwell/menu/iconmenu'`.

Ideally the entire build system would be re-written, some folders have their own makefiles, others use a mix of the main and `Rules.make`, but this is a good middle ground.