### PR TITLE
video: Space between text should be an even number

### DIFF
--- a/drivers/video/BootVideoHelpers.c
+++ b/drivers/video/BootVideoHelpers.c
@@ -20,7 +20,7 @@
 #include "fontx16.h"  // brings in font struct
 #include <stdarg.h>
 #include "decode-jpg.h"
-#define WIDTH_SPACE_PIXELS 5
+#define WIDTH_SPACE_PIXELS 4
 
 // returns number of x pixels taken up by ascii character bCharacter
 


### PR DESCRIPTION
Very subtle but imo looks better having 4 pixel width between strings.

5px:
![5](https://user-images.githubusercontent.com/858612/90584450-a35cb400-e1a0-11ea-8b60-16e826bbe612.png)

4px:
![4](https://user-images.githubusercontent.com/858612/90584461-a657a480-e1a0-11ea-803b-3f0f0c565b84.png)
