### PR TITLE
ui: Add serial port IRQ menu option to Peripherals menu

### DIFF
--- a/include/boot.h
+++ b/include/boot.h
@@ -266,6 +266,8 @@ void LpcEnterConfiguration(void);
 void LpcExitConfiguration(void);
 int LpcGetSerialState(void);
 void LpcSetSerialState(int enable);
+int LpcGetSerialIRQState(void);
+void LpcSetSerialIRQState(int enable);
 
 ///////// BootPerformPicChallengeResponseAction.c
 

--- a/menu/actions/PhyMenuActions.h
+++ b/menu/actions/PhyMenuActions.h
@@ -9,9 +9,12 @@
  *                                                                         *
  ***************************************************************************/
 
-int CurrentSerialState;
+extern int CurrentSerialState;
+extern int CurrentSerialIRQState;
 
 int IsSerialEnabled(void);
 void SetSerialEnabled(void *);
+int HasSerialIRQ(void);
+void SetSerialIRQ(void *);
 
 #endif

--- a/menu/textmenu/PhyMenuInit.c
+++ b/menu/textmenu/PhyMenuInit.c
@@ -21,14 +21,23 @@ TEXTMENU *PhyMenuInit(void) {
 	memset(menuPtr,0x00,sizeof(TEXTMENU));
 	strcpy(menuPtr->szCaption, "Peripherals Menu");
 
-
 	CurrentSerialState = IsSerialEnabled();
 
 	itemPtr = malloc(sizeof(TEXTMENUITEM));
 	memset(itemPtr,0x00,sizeof(TEXTMENUITEM));
 	strcpy(itemPtr->szCaption, "Serial COM1: ");
-	strcat(itemPtr->szCaption, (CurrentSerialState ? "Enabled" : "Disabled"));
+	strcat(itemPtr->szCaption, (CurrentSerialState) ? "Enabled" : "Disabled");
 	itemPtr->functionPtr = SetSerialEnabled;
+	itemPtr->functionDataPtr = itemPtr->szCaption;
+	TextMenuAddItem(menuPtr, itemPtr);
+
+	CurrentSerialIRQState = HasSerialIRQ();
+
+	itemPtr = malloc(sizeof(TEXTMENUITEM));
+	memset(itemPtr,0x00,sizeof(TEXTMENUITEM));
+	strcpy(itemPtr->szCaption, "Serial COM1 IRQ: ");
+	strcat(itemPtr->szCaption, (CurrentSerialIRQState) ? "4 (conflicts with NIC)" : "Disabled");
+	itemPtr->functionPtr = SetSerialIRQ;
 	itemPtr->functionDataPtr = itemPtr->szCaption;
 	TextMenuAddItem(menuPtr, itemPtr);
 


### PR DESCRIPTION
This makes it possible to enable or disable Serial COM1's interrupt so that there is no conflict with NIC. Enabling IRQ for Serial COM1 (on by default) will conflict with NIC (nvnet). Disabling the IRQ will disable serial input (unless there's polling).