### PR TITLE
boot: Increase compatibility with xemu emulator

### DIFF
--- a/boot_rom/Xcodes.h
+++ b/boot_rom/Xcodes.h
@@ -287,8 +287,12 @@
 	xcode_pciout(0x80010010, 0xfd000000);
 	
 	
-	// overflow trick
-	xcode_poke(0x00000000, 0xfc1000ea);
-	xcode_poke(0x00000004, 0x000008ff);
+	// overflow trick (execution continues in 2bBootStartup.S)
+	// mov eax, 0xfffc1000
+	// jmp eax
+	// nop
+	xcode_poke(0x00000000, 0xfc1000B8);
+	xcode_poke(0x00000004, 0x90e0ffff);
+	
 
        	xcode_END(0x806);


### PR DESCRIPTION
This change is functionally equivalent to the original while also fixing compatibility with newer versions of xemu that now enforce MCPX ROM overlay disablement as discussed in https://github.com/mborgerson/xemu/issues/243. Without these changes xemu gets stuck in a reset loop due to the Cromwell image having clobbered GDT/IDT tables at the end of the image which qemu doesn't cache in memory/cpu like original hardware appears to do.

Setting [this](https://github.com/XboxDev/cromwell/blob/e2d1f85ce1778f0cec673b9b882b716e3bae4155/lib/imagebld/imagebld.c#L56) to be only 8 characters (non null-terminated "Cromwell") and then setting up the GDT/IDT in the following 24 (it starts with a 0 so the previous string ends up null-terminated) would also be acceptable, but I figured updating the VISOR jump method would be the simpler approach and less chance of interfering with any legacy functionality.