### PR TITLE
ci: Fix package installation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Dependencies
-      run: sudo apt install gcc-multilib
+      run: sudo apt update && sudo apt install gcc-multilib
     - name: Checkout
       uses: actions/checkout@v2
     - name: Create Build Tag


### PR DESCRIPTION
My last PR was missing a package index update command, causing package installation to fail.