### PR TITLE
boot: Clear .bss section

### DIFF
--- a/boot/BootStartup.S
+++ b/boot/BootStartup.S
@@ -136,6 +136,12 @@ reload_cs:
 	// Set the stack pointer to give us a valid stack
 	movl $STACK_TOP, %esp
 
+	// Clear out .bss
+	xor %eax, %eax
+	mov $BSS_SIZE_L, %ecx
+	mov $BSS_BASE, %edi
+	rep stosl
+
     // We clear the IDT in RAM   (IDT located @  0xb0000 )
 	xor %eax, %eax
 	movl $0x5000/4, %ecx

--- a/boot_rom/2bBootStartup.S
+++ b/boot_rom/2bBootStartup.S
@@ -339,7 +339,14 @@ reload_cs:
 	mov %eax, %fs
 	mov %eax, %gs
 
-	movl	$ 0x1ffff0,%esp
+	// Set the stack pointer to give us a valid stack
+	movl $0x1ffff0, %esp
+
+	// Clear out .bss
+	xor %eax, %eax
+	mov $BSS_SIZE_L, %ecx
+	mov $BSS_BASE, %edi
+	rep stosl
 
 	mov	$0x8, %al
 	mov	$0x61, %dx

--- a/boot_rom/bootrom.ld
+++ b/boot_rom/bootrom.ld
@@ -57,12 +57,14 @@ SECTIONS {
 	}
 
 	.bss ( RAM_CODE + SIZEOF(.text) + SIZEOF(.data) + SIZEOF(.rodata) ) : AT ( SIZEOF(.low_rom) + SIZEOF(.text) + SIZEOF(.data) + SIZEOF(.rodata)) {
+		BSS_BASE = .;
 		_bss = .;
 		*(.bss)
 		*(.sbss)
 		*(COMMON)
 		_ebss = . ;
 		_heap = . ;
+		BSS_END = .;
 	}
 
         /* We need to copy the .data section to to upper memory */
@@ -79,3 +81,7 @@ SECTIONS {
 */
 
 }
+
+BSS_SIZE = BSS_END - BSS_BASE;
+BSS_SIZE_L = BSS_SIZE / 4;
+

--- a/scripts/ldscript-crom.ld
+++ b/scripts/ldscript-crom.ld
@@ -59,13 +59,19 @@ SECTIONS {
 	/* the data (initialized globals) is moved to ram by the startup code */
 
 	.bss (LOW_ROM + SIZEOF(.text) + SIZEOF(.rodata) + SIZEOF(.data)) : AT( SIZEOF(.text) + SIZEOF(.rodata) + SIZEOF(.data)) {
+		BSS_BASE = .;
 		_bss = .;
 		*(.bss)
 		*(.sbss)
 		*(COMMON)
 		_ebss = . ;
 		_heap = . ;
+		BSS_END = .;
 	}
 
 	_end_complete_rom = SIZEOF(.text) + SIZEOF(.rodata) + SIZEOF(.data) + SIZEOF(.bss);
 }
+
+BSS_SIZE = BSS_END - BSS_BASE;
+BSS_SIZE_L = BSS_SIZE / 4;
+


### PR DESCRIPTION
Cromwell never cleared the .bss section, which resulted in issues like #48, and this commit supersedes that. This also fixes an issue where the icon menu does not show up again after a power cycle.